### PR TITLE
Add Bluesky post unfurling for Slack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ Camille is an extensible Slack bot built on Cloudflare Workers with TypeScript.
 - `project_docs/cloudflare_deployment.md` - Deployment instructions
 - `project_docs/documentation.md` - Running documentation
 
+## Pull Requests
+
+All PRs should be made against `mergesort/Camille`.
+
 ## Quick Start
 
 ```bash

--- a/camille-bot/src/bluesky-unfurl/bluesky.ts
+++ b/camille-bot/src/bluesky-unfurl/bluesky.ts
@@ -1,0 +1,338 @@
+/**
+ * Bluesky API Client
+ *
+ * Fetches post data from Bluesky's public API
+ */
+
+import { Logger } from '../shared/logging/logger';
+
+const BSKY_PUBLIC_API = 'https://public.api.bsky.app/xrpc';
+
+// Bluesky embed types
+export type BlueskyEmbed =
+  | BlueskyImageEmbed
+  | BlueskyVideoEmbed
+  | BlueskyExternalEmbed
+  | BlueskyRecordEmbed
+  | BlueskyRecordWithMediaEmbed;
+
+export interface BlueskyImageEmbed {
+  $type: 'app.bsky.embed.images#view';
+  images: Array<{
+    thumb: string;
+    fullsize: string;
+    alt: string;
+  }>;
+}
+
+export interface BlueskyVideoEmbed {
+  $type: 'app.bsky.embed.video#view';
+  cid: string;
+  playlist: string;
+  thumbnail?: string;
+  aspectRatio?: {
+    width: number;
+    height: number;
+  };
+}
+
+export interface BlueskyExternalEmbed {
+  $type: 'app.bsky.embed.external#view';
+  external: {
+    uri: string;
+    title: string;
+    description: string;
+    thumb?: string;
+  };
+}
+
+export interface BlueskyViewRecord {
+  $type: 'app.bsky.embed.record#viewRecord';
+  uri: string;
+  cid: string;
+  author: {
+    handle: string;
+    displayName?: string;
+    avatar?: string;
+  };
+  value: {
+    text: string;
+    createdAt: string;
+  };
+  embeds?: BlueskyEmbed[];
+}
+
+export interface BlueskyViewNotFound {
+  $type: 'app.bsky.embed.record#viewNotFound';
+  uri: string;
+}
+
+export interface BlueskyViewBlocked {
+  $type: 'app.bsky.embed.record#viewBlocked';
+  uri: string;
+}
+
+export type BlueskyRecordView =
+  | BlueskyViewRecord
+  | BlueskyViewNotFound
+  | BlueskyViewBlocked;
+
+export interface BlueskyRecordEmbed {
+  $type: 'app.bsky.embed.record#view';
+  record: BlueskyRecordView;
+}
+
+export interface BlueskyRecordWithMediaEmbed {
+  $type: 'app.bsky.embed.recordWithMedia#view';
+  record: BlueskyRecordEmbed;
+  media: BlueskyImageEmbed | BlueskyVideoEmbed;
+}
+
+export interface BlueskyPost {
+  text: string;
+  author: {
+    handle: string;
+    displayName?: string;
+    avatar?: string;
+  };
+  embed?: BlueskyEmbed;
+  createdAt: string;
+}
+
+type ParsedBlueskyUrl =
+  | { status: 'success'; handle: string; rkey: string }
+  | { status: 'invalid' };
+
+export function parseBlueskyUrl(url: string): ParsedBlueskyUrl {
+  // Matches: https://bsky.app/profile/{handle}/post/{rkey}
+  const match = url.match(
+    /^https?:\/\/bsky\.app\/profile\/([^/]+)\/post\/([^/?#]+)/
+  );
+
+  if (!match) {
+    return { status: 'invalid' };
+  }
+
+  return {
+    status: 'success',
+    handle: match[1],
+    rkey: match[2],
+  };
+}
+
+export function isBlueskyUrl(url: string): boolean {
+  return url.includes('bsky.app/profile/') && url.includes('/post/');
+}
+
+type ResolveHandleResult =
+  | { status: 'success'; did: string }
+  | { status: 'error'; message: string };
+
+async function resolveHandle(handle: string): Promise<ResolveHandleResult> {
+  // If it's already a DID, return it
+  if (handle.startsWith('did:')) {
+    return { status: 'success', did: handle };
+  }
+
+  const response = await fetch(
+    `${BSKY_PUBLIC_API}/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(handle)}`
+  );
+
+  if (!response.ok) {
+    return { status: 'error', message: `Failed to resolve handle: ${handle}` };
+  }
+
+  const data = (await response.json()) as { did: string };
+  return { status: 'success', did: data.did };
+}
+
+type FetchPostResult =
+  | { status: 'success'; post: BlueskyPost; postUrl: string }
+  | { status: 'error'; message: string };
+
+export async function fetchBlueskyPost(
+  url: string,
+  logger: Logger
+): Promise<FetchPostResult> {
+  const parsed = parseBlueskyUrl(url);
+  if (parsed.status === 'invalid') {
+    return { status: 'error', message: 'Invalid Bluesky URL' };
+  }
+
+  const { handle, rkey } = parsed;
+
+  logger.debug('Fetching Bluesky post', { handle, rkey });
+
+  const resolveResult = await resolveHandle(handle);
+  if (resolveResult.status === 'error') {
+    logger.warn('Failed to resolve Bluesky handle', { handle, error: resolveResult.message });
+    return resolveResult;
+  }
+
+  const { did } = resolveResult;
+  const atUri = `at://${did}/app.bsky.feed.post/${rkey}`;
+
+  const response = await fetch(
+    `${BSKY_PUBLIC_API}/app.bsky.feed.getPostThread?uri=${encodeURIComponent(atUri)}&depth=0`
+  );
+
+  if (!response.ok) {
+    logger.warn('Failed to fetch Bluesky post', { atUri, status: response.status });
+    return { status: 'error', message: `Failed to fetch post: ${response.status}` };
+  }
+
+  const data = (await response.json()) as {
+    thread: {
+      $type?: string;
+      post?: {
+        uri: string;
+        cid: string;
+        author: {
+          did: string;
+          handle: string;
+          displayName?: string;
+          avatar?: string;
+        };
+        record: {
+          text: string;
+          createdAt: string;
+          embed?: unknown;
+        };
+        embed?: BlueskyEmbed;
+      };
+    };
+  };
+
+  if (!data.thread.post) {
+    logger.warn('Bluesky post not available', { atUri, threadType: data.thread.$type });
+    return { status: 'error', message: 'Post is not available (deleted or blocked)' };
+  }
+
+  const post = data.thread.post;
+
+  logger.debug('Successfully fetched Bluesky post', {
+    handle: post.author.handle,
+    hasEmbed: !!post.embed,
+    embedType: post.embed?.$type
+  });
+
+  return {
+    status: 'success',
+    post: {
+      text: post.record.text,
+      author: {
+        handle: post.author.handle,
+        displayName: post.author.displayName,
+        avatar: post.author.avatar,
+      },
+      embed: post.embed,
+      createdAt: post.record.createdAt,
+    },
+    postUrl: url,
+  };
+}
+
+export interface ExtractedImage {
+  url: string;
+  alt?: string;
+}
+
+type ExtractedMedia =
+  | { type: 'none' }
+  | { type: 'images'; images: ExtractedImage[] }
+  | { type: 'video'; thumbnailUrl?: string; playlistUrl: string }
+  | { type: 'external'; title: string; description: string; thumb?: string; uri: string };
+
+export interface ExtractedQuote {
+  text: string;
+  author: {
+    handle: string;
+    displayName?: string;
+    avatar?: string;
+  };
+  media: ExtractedMedia;
+}
+
+function extractQuoteFromRecord(record: BlueskyRecordView): ExtractedQuote | undefined {
+  if (record.$type !== 'app.bsky.embed.record#viewRecord') {
+    return undefined;
+  }
+
+  const media = record.embeds?.length
+    ? extractMedia(record.embeds[0])
+    : { type: 'none' as const };
+
+  return {
+    text: record.value.text,
+    author: {
+      handle: record.author.handle,
+      displayName: record.author.displayName,
+      avatar: record.author.avatar,
+    },
+    media,
+  };
+}
+
+export function extractQuote(embed: BlueskyEmbed | undefined): ExtractedQuote | undefined {
+  if (!embed) {
+    return undefined;
+  }
+
+  switch (embed.$type) {
+    case 'app.bsky.embed.record#view':
+      return extractQuoteFromRecord(embed.record);
+
+    case 'app.bsky.embed.recordWithMedia#view':
+      return extractQuoteFromRecord(embed.record.record);
+
+    default:
+      return undefined;
+  }
+}
+
+export function extractMedia(embed: BlueskyEmbed | undefined): ExtractedMedia {
+  if (!embed) {
+    return { type: 'none' };
+  }
+
+  switch (embed.$type) {
+    case 'app.bsky.embed.images#view':
+      if (embed.images.length > 0) {
+        return {
+          type: 'images',
+          images: embed.images.map((img) => ({
+            url: img.thumb,
+            alt: img.alt,
+          })),
+        };
+      }
+      return { type: 'none' };
+
+    case 'app.bsky.embed.video#view':
+      return {
+        type: 'video',
+        thumbnailUrl: embed.thumbnail,
+        playlistUrl: embed.playlist,
+      };
+
+    case 'app.bsky.embed.external#view':
+      return {
+        type: 'external',
+        title: embed.external.title,
+        description: embed.external.description,
+        thumb: embed.external.thumb,
+        uri: embed.external.uri,
+      };
+
+    case 'app.bsky.embed.recordWithMedia#view':
+      // Extract media from the nested media object
+      return extractMedia(embed.media);
+
+    case 'app.bsky.embed.record#view':
+      // Quote posts don't have direct media
+      return { type: 'none' };
+
+    default:
+      return { type: 'none' };
+  }
+}

--- a/camille-bot/src/bluesky-unfurl/index.ts
+++ b/camille-bot/src/bluesky-unfurl/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Bluesky Unfurl Module
+ *
+ * Handles unfurling Bluesky post links in Slack
+ */
+
+export { isBlueskyUrl, fetchBlueskyPost, extractQuote } from './bluesky';
+export type { ExtractedQuote } from './bluesky';
+export { formatUnfurl, SlackUnfurlAttachment } from './unfurl';

--- a/camille-bot/src/bluesky-unfurl/unfurl.ts
+++ b/camille-bot/src/bluesky-unfurl/unfurl.ts
@@ -11,8 +11,9 @@ import { BlueskyPost, extractMedia, extractQuote, ExtractedQuote } from './blues
 const BLUESKY_BLUE = '#0085ff';
 
 export interface SlackUnfurlAttachment {
-  title?: string;
-  title_link?: string;
+  author_name?: string;
+  author_icon?: string;
+  author_link?: string;
   text?: string;
   image_url?: string;
   thumb_url?: string;
@@ -61,14 +62,15 @@ function formatAttachment(
   text: string | undefined
 ): SlackUnfurlAttachment {
   const authorName = post.author.displayName || post.author.handle;
-  const title = post.author.displayName
+  const displayTitle = post.author.displayName
     ? `${authorName} (@${post.author.handle})`
     : `@${post.author.handle}`;
 
   const attachment: SlackUnfurlAttachment = {
     color: BLUESKY_BLUE,
-    title,
-    title_link: postUrl,
+    author_name: displayTitle,
+    author_link: postUrl,
+    ...(post.author.avatar && { author_icon: post.author.avatar }),
   };
 
   // Track whether we've already embedded a link to the post in the text

--- a/camille-bot/src/bluesky-unfurl/unfurl.ts
+++ b/camille-bot/src/bluesky-unfurl/unfurl.ts
@@ -9,6 +9,7 @@
 import { BlueskyPost, extractMedia, extractQuote, ExtractedQuote } from './bluesky';
 
 const BLUESKY_BLUE = '#0085ff';
+const BLUESKY_LOGO = 'https://bsky.app/static/apple-touch-icon.png';
 
 export interface SlackUnfurlAttachment {
   author_name?: string;
@@ -71,6 +72,9 @@ function formatAttachment(
     author_name: displayTitle,
     author_link: postUrl,
     ...(post.author.avatar && { author_icon: post.author.avatar }),
+    footer: 'Bluesky',
+    footer_icon: BLUESKY_LOGO,
+    ts: Math.floor(new Date(post.createdAt).getTime() / 1000),
   };
 
   // Track whether we've already embedded a link to the post in the text

--- a/camille-bot/src/bluesky-unfurl/unfurl.ts
+++ b/camille-bot/src/bluesky-unfurl/unfurl.ts
@@ -1,0 +1,125 @@
+/**
+ * Bluesky Unfurl Formatter
+ *
+ * Converts Bluesky posts to Slack legacy unfurl attachments.
+ * Always uses legacy attachment fields (color, title_link, text, image_url)
+ * to preserve the blue color bar. Only the first image is shown for multi-image posts.
+ */
+
+import { BlueskyPost, extractMedia, extractQuote, ExtractedQuote } from './bluesky';
+
+const BLUESKY_BLUE = '#0085ff';
+
+export interface SlackUnfurlAttachment {
+  title?: string;
+  title_link?: string;
+  text?: string;
+  image_url?: string;
+  thumb_url?: string;
+  color?: string;
+  footer?: string;
+  footer_icon?: string;
+  ts?: number;
+}
+
+function formatQuoteText(quote: ExtractedQuote): string {
+  const authorName = quote.author.displayName || quote.author.handle;
+
+  let result = `*Quoting ${authorName}* (@${quote.author.handle})`;
+
+  if (quote.text) {
+    const blockquoted = quote.text
+      .split('\n')
+      .map((line) => `> ${line}`)
+      .join('\n');
+    result += `\n${blockquoted}`;
+  }
+
+  return result;
+}
+
+export function formatUnfurl(post: BlueskyPost, postUrl: string): SlackUnfurlAttachment {
+  const media = extractMedia(post.embed);
+  const quote = extractQuote(post.embed);
+
+  // Build the main text, appending quote if present
+  let text = post.text;
+
+  if (quote) {
+    const quoteSection = formatQuoteText(quote);
+    text = text ? `${text}\n\n${quoteSection}` : quoteSection;
+  }
+
+  return formatAttachment(post, postUrl, media, quote, text);
+}
+
+function formatAttachment(
+  post: BlueskyPost,
+  postUrl: string,
+  media: ReturnType<typeof extractMedia>,
+  quote: ExtractedQuote | undefined,
+  text: string | undefined
+): SlackUnfurlAttachment {
+  const authorName = post.author.displayName || post.author.handle;
+  const title = post.author.displayName
+    ? `${authorName} (@${post.author.handle})`
+    : `@${post.author.handle}`;
+
+  const attachment: SlackUnfurlAttachment = {
+    color: BLUESKY_BLUE,
+    title,
+    title_link: postUrl,
+  };
+
+  // Track whether we've already embedded a link to the post in the text
+  let hasInlineLink = false;
+
+  switch (media.type) {
+    case 'images':
+      attachment.image_url = media.images[0].url;
+      if (media.images.length > 1) {
+        text = (text || '') + (text ? '\n\n' : '') + `:camera: <${postUrl}|This post contains ${media.images.length} images>`;
+        hasInlineLink = true;
+      }
+      break;
+
+    case 'video':
+      text = (text || '') + (text ? '\n\n' : '') + `:movie_camera: <${postUrl}|This post contains a video>`;
+      hasInlineLink = true;
+      if (media.thumbnailUrl) {
+        attachment.image_url = media.thumbnailUrl;
+      }
+      break;
+
+    case 'external': {
+      const linkLine = `:link: <${media.uri}|${media.title}>`;
+      text = text ? `${text}\n\n${linkLine}` : linkLine;
+      if (media.thumb) {
+        attachment.image_url = media.thumb;
+      }
+      break;
+    }
+
+    case 'none':
+      // If no main media, fall through to quoted post media
+      if (quote?.media.type === 'images') {
+        attachment.image_url = quote.media.images[0].url;
+      } else if (quote?.media.type === 'video') {
+        text = (text || '') + (text ? '\n\n' : '') + `:movie_camera: <${postUrl}|Quoted post contains a video>`;
+        hasInlineLink = true;
+        if (quote.media.thumbnailUrl) {
+          attachment.image_url = quote.media.thumbnailUrl;
+        }
+      }
+      break;
+  }
+
+  if (hasInlineLink) {
+    attachment.text = text;
+  } else {
+    const linkSuffix = `<${postUrl}|View on Bluesky>`;
+    attachment.text = text ? `${text}\n\n${linkSuffix}` : linkSuffix;
+  }
+
+  return attachment;
+}

--- a/camille-bot/src/shared/slack/messaging.ts
+++ b/camille-bot/src/shared/slack/messaging.ts
@@ -111,6 +111,9 @@ export async function addSlackReaction(options: {
 export interface UnfurlAttachment {
   title?: string;
   title_link?: string;
+  author_name?: string;
+  author_icon?: string;
+  author_link?: string;
   text?: string;
   image_url?: string;
   thumb_url?: string;

--- a/camille-bot/src/shared/slack/messaging.ts
+++ b/camille-bot/src/shared/slack/messaging.ts
@@ -83,13 +83,13 @@ export async function addSlackReaction(options: {
   token: string;
 }): Promise<void> {
   const { channel, timestamp, reaction, token } = options;
-  
+
   const payload = {
     channel,
     timestamp,
     name: reaction
   };
-  
+
   const response = await fetch('https://slack.com/api/reactions.add', {
     method: 'POST',
     headers: {
@@ -98,9 +98,57 @@ export async function addSlackReaction(options: {
     },
     body: JSON.stringify(payload)
   });
-  
+
   if (!response.ok) {
     const errorData = await response.text();
     throw new Error(`Failed to add reaction: ${errorData}`);
+  }
+}
+
+/**
+ * Unfurl attachment type for chat.unfurl API
+ */
+export interface UnfurlAttachment {
+  title?: string;
+  title_link?: string;
+  text?: string;
+  image_url?: string;
+  thumb_url?: string;
+  color?: string;
+  footer?: string;
+  footer_icon?: string;
+  ts?: number;
+}
+
+/**
+ * Send unfurls for links shared in a Slack message
+ */
+export async function sendSlackUnfurl(options: {
+  channel: string;
+  ts: string;
+  unfurls: Record<string, UnfurlAttachment>;
+  token: string;
+}): Promise<void> {
+  const { channel, ts, unfurls, token } = options;
+
+  const payload = {
+    channel,
+    ts,
+    unfurls
+  };
+
+  const response = await fetch('https://slack.com/api/chat.unfurl', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`
+    },
+    body: JSON.stringify(payload)
+  });
+
+  const data = await response.json() as { ok: boolean; error?: string };
+
+  if (!data.ok) {
+    throw new Error(`Failed to unfurl links: ${data.error || 'Unknown error'}`);
   }
 } 

--- a/camille-bot/src/shared/slack/types.ts
+++ b/camille-bot/src/shared/slack/types.ts
@@ -62,4 +62,21 @@ export interface SlackMessageResponse extends SlackApiResponse {
     text: string;
     blocks?: any[];
   };
+}
+
+/**
+ * Link shared event types for unfurling
+ */
+export interface SlackLinkSharedEvent {
+  type: 'link_shared';
+  channel: string;
+  user: string;
+  message_ts: string;
+  thread_ts?: string;
+  links: SlackLink[];
+}
+
+export interface SlackLink {
+  domain: string;
+  url: string;
 } 


### PR DESCRIPTION
## Summary

- Adds Bluesky post link unfurling when users share bsky.app links in Slack
- Supports single images, multi-image posts (first image + count indicator), videos, external embeds, and quoted posts
- Integrates with Bluesky's public API to fetch post data and renders rich Slack previews with author info, post text, and media

## Details

New `bluesky-unfurl` module with two main components:
- **`bluesky.ts`** - Bluesky API client that resolves handles, fetches post threads, and extracts media/quotes from various embed types
- **`unfurl.ts`** - Formats Bluesky posts into Slack legacy unfurl attachments (preserves blue color bar)

Also adds:
- `link_shared` event handling in the Slack events router
- `sendSlackUnfurl` helper wrapping Slack's `chat.unfurl` API
- `SlackLinkSharedEvent` type definitions

## Slack App Configuration

To enable Bluesky unfurling, the following changes are needed in the [Slack App settings](https://api.slack.com/apps):

1. **OAuth Scopes** — Add these Bot Token scopes under **OAuth & Permissions**:
   - `links:read`
   - `links:write`

2. **Event Subscription** — Under **Event Subscriptions**, subscribe to the bot event:
   - `link_shared`

3. **App Unfurl Domains** — Under **Event Subscriptions > App Unfurl Domains**, add:
   - `bsky.app`

4. **Reinstall the app** to the workspace so the new scopes take effect.

## Test plan

- [ ] Share a Bluesky text-only post link in Slack and verify it unfurls with author and text
- [ ] Share a Bluesky post with a single image and verify the image appears with the blue color bar
- [ ] Share a Bluesky post with multiple images and verify the first image shows with a count indicator
- [ ] Share a Bluesky post with a video and verify the video thumbnail and camera emoji appear
- [ ] Share a Bluesky post with an external link embed and verify the link title and thumbnail appear
- [ ] Share a Bluesky post that quotes another post and verify the quoted content appears
- [ ] Share a non-Bluesky link and verify it is not affected

## How it looks
<img width="400" alt="CleanShot 2026-02-08 at 12 29 45@2x" src="https://github.com/user-attachments/assets/a17067cc-d313-4b3f-80ec-4a947655211d" />
<img width="400" alt="CleanShot 2026-02-08 at 12 30 26@2x" src="https://github.com/user-attachments/assets/0f926b31-09bc-420f-b74c-f3d467c58491" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)