### PR TITLE
add fxtwitter.com and ios.horse to the twitter link regex for xcancel url replies

### DIFF
--- a/camille-bot/src/karma/karma.ts
+++ b/camille-bot/src/karma/karma.ts
@@ -8,10 +8,9 @@ import { Logger } from '../shared/logging/logger';
 import { KVStore } from '../shared/storage/kv-store';
 import { Config } from '../shared/config/config';
 import { updateUserKarma, getUserKarma, KarmaData, getKarmaLeaderboard } from './storage';
-import { KVNamespace } from "@cloudflare/workers-types";
-import { z } from "zod";
-import { KARMA_KEY_PREFIX } from "./storage";
-import { 
+import { KVNamespace } from '@cloudflare/workers-types';
+import { KARMA_KEY_PREFIX } from './storage';
+import {
   KARMA_INCREMENT_REGEX,
   KARMA_DECREMENT_REGEX,
   KARMA_ADD_REGEX,

--- a/camille-bot/src/shared/regex/patterns.ts
+++ b/camille-bot/src/shared/regex/patterns.ts
@@ -57,7 +57,7 @@ export const EXTENDED_URL_REGEX = /(?:https?:\/\/)?(?:www\.)?[-a-zA-Z0-9@:%._\+~
  * Matches URLs from twitter.com or x.com domains
  * Uses word boundaries to ensure exact domain matching
  */
-export const X_TWITTER_URL_REGEX = /(?:https?:\/\/)?(?:www\.)?\b(twitter\.com|x\.com)\b(?:\/[^\s]*)?/gi;
+export const X_TWITTER_URL_REGEX = /(?:https?:\/\/)?(?:www\.)?\b(twitter\.com|x\.com|fxtwitter\.com|ios\.horse)\b(?:\/[^\s]*)?/gi;
 
 // ============================
 // KARMA PATTERNS

--- a/camille-bot/src/x-transformer/__tests__/x-transformer.test.ts
+++ b/camille-bot/src/x-transformer/__tests__/x-transformer.test.ts
@@ -4,20 +4,21 @@
 
 import { processXLinks, transformXToXcancel, deduplicateUrls } from '../x-transformer';
 import { Logger } from '../../shared/logging/logger';
+import { X_TWITTER_URL_REGEX } from '../../shared/regex/patterns';
 
 // Mock logger
 const mockLogger: Logger = {
   debug: jest.fn(),
   info: jest.fn(),
   warn: jest.fn(),
-  error: jest.fn()
+  error: jest.fn(),
 };
 
 describe('X/Twitter Transformer Module', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  
+
   describe('transformXToXcancel', () => {
     test('should transform x.com to xcancel.com', () => {
       expect(transformXToXcancel('x.com')).toBe('https://xcancel.com');
@@ -25,86 +26,115 @@ describe('X/Twitter Transformer Module', () => {
       expect(transformXToXcancel('http://x.com')).toBe('https://xcancel.com');
       expect(transformXToXcancel('www.x.com')).toBe('https://xcancel.com');
     });
-    
+
     test('should transform twitter.com to xcancel.com', () => {
       expect(transformXToXcancel('twitter.com')).toBe('https://xcancel.com');
       expect(transformXToXcancel('https://twitter.com')).toBe('https://xcancel.com');
       expect(transformXToXcancel('http://twitter.com')).toBe('https://xcancel.com');
       expect(transformXToXcancel('www.twitter.com')).toBe('https://xcancel.com');
     });
-    
+
     test('should preserve paths when transforming', () => {
-      expect(transformXToXcancel('x.com/profile/mergesort')).toBe('https://xcancel.com/profile/mergesort');
-      expect(transformXToXcancel('twitter.com/profile/mergesort')).toBe('https://xcancel.com/profile/mergesort');
-      expect(transformXToXcancel('https://x.com/mergesort/status/594915993060777984')).toBe('https://xcancel.com/mergesort/status/594915993060777984');
+      expect(transformXToXcancel('x.com/profile/mergesort')).toBe(
+        'https://xcancel.com/profile/mergesort'
+      );
+      expect(transformXToXcancel('twitter.com/profile/mergesort')).toBe(
+        'https://xcancel.com/profile/mergesort'
+      );
+      expect(transformXToXcancel('https://x.com/mergesort/status/594915993060777984')).toBe(
+        'https://xcancel.com/mergesort/status/594915993060777984'
+      );
     });
-    
+
     test('should handle query parameters and hash fragments', () => {
       expect(transformXToXcancel('x.com/search?q=test')).toBe('https://xcancel.com/search?q=test');
-      expect(transformXToXcancel('twitter.com/profile/mergesort?lang=en')).toBe('https://xcancel.com/profile/mergesort?lang=en');
-      expect(transformXToXcancel('https://x.com/search?q=test#results')).toBe('https://xcancel.com/search?q=test#results');
+      expect(transformXToXcancel('twitter.com/profile/mergesort?lang=en')).toBe(
+        'https://xcancel.com/profile/mergesort?lang=en'
+      );
+      expect(transformXToXcancel('https://x.com/search?q=test#results')).toBe(
+        'https://xcancel.com/search?q=test#results'
+      );
     });
-    
+
     test('should handle Slack formatting', () => {
-      expect(transformXToXcancel('<https://x.com/profile/mergesort>')).toBe('https://xcancel.com/profile/mergesort');
-      expect(transformXToXcancel('<https://twitter.com/profile/mergesort|Twitter Profile>')).toBe('https://xcancel.com/profile/mergesort');
+      expect(transformXToXcancel('<https://x.com/profile/mergesort>')).toBe(
+        'https://xcancel.com/profile/mergesort'
+      );
+      expect(transformXToXcancel('<https://twitter.com/profile/mergesort|Twitter Profile>')).toBe(
+        'https://xcancel.com/profile/mergesort'
+      );
     });
-    
+
     test('should handle unusual formats', () => {
       // Test with trailing slash
       expect(transformXToXcancel('x.com/')).toBe('https://xcancel.com/');
-      
+
       // Test with path but no protocol
       expect(transformXToXcancel('x.com/trending')).toBe('https://xcancel.com/trending');
     });
   });
-  
+
   describe('processXLinks', () => {
     test('should detect and transform a single X/Twitter link', async () => {
-      const result = await processXLinks('Check out this post: https://x.com/mergesort/status/594915993060777984', mockLogger);
-      
+      const result = await processXLinks(
+        'Check out this post: https://x.com/mergesort/status/594915993060777984',
+        mockLogger
+      );
+
       expect(result.hasXLinks).toBe(true);
       expect(result.originalLinks).toHaveLength(1);
       expect(result.transformedLinks).toHaveLength(1);
-      expect(result.transformedLinks[0]).toBe('https://xcancel.com/mergesort/status/594915993060777984');
+      expect(result.transformedLinks[0]).toBe(
+        'https://xcancel.com/mergesort/status/594915993060777984'
+      );
       expect(mockLogger.info).toHaveBeenCalled();
     });
-    
+
     test('should detect and transform multiple X/Twitter links', async () => {
       const result = await processXLinks(
         'Two links: https://twitter.com/profile/user1 and https://x.com/profile/user2',
         mockLogger
       );
-      
+
       expect(result.hasXLinks).toBe(true);
       expect(result.originalLinks).toHaveLength(2);
       expect(result.transformedLinks).toHaveLength(2);
       expect(result.transformedLinks).toContain('https://xcancel.com/profile/user1');
       expect(result.transformedLinks).toContain('https://xcancel.com/profile/user2');
     });
-    
+
+    test('should handle alternative x links correctly', async () => {
+      const result = await processXLinks(
+        'Check this link: https://ios.horse/profile/mergesort and this link: https://fxtwitter.com/profile/someone_else',
+        mockLogger
+      );
+
+      expect(result.hasXLinks).toBe(true);
+      expect(result.originalLinks).toHaveLength(2);
+      expect(result.transformedLinks).toHaveLength(2);
+      expect(result.transformedLinks[0]).toBe('https://xcancel.com/profile/mergesort');
+      expect(result.transformedLinks[1]).toBe('https://xcancel.com/profile/someone_else');
+    });
+
     test('should handle messages without X/Twitter links', async () => {
       const result = await processXLinks(
         'No X/Twitter links here, only https://example.com',
         mockLogger
       );
-      
+
       expect(result.hasXLinks).toBe(false);
       expect(result.originalLinks).toHaveLength(0);
       expect(result.transformedLinks).toHaveLength(0);
     });
-    
+
     test('should handle errors gracefully', async () => {
       // Mock logger.debug to throw an error
       mockLogger.debug = jest.fn().mockImplementation(() => {
         throw new Error('Forced error for testing');
       });
-      
-      const result = await processXLinks(
-        'Check out https://x.com/test',
-        mockLogger
-      );
-      
+
+      const result = await processXLinks('Check out https://x.com/test', mockLogger);
+
       expect(result.hasXLinks).toBe(false);
       expect(result.originalLinks).toHaveLength(0);
       expect(result.transformedLinks).toHaveLength(0);
@@ -116,26 +146,23 @@ describe('X/Twitter Transformer Module', () => {
       // when run within the test framework, but works fine in our standalone tests.
       console.log('Skipping deduplication test for now');
       return;
-      
+
       // Original test code
       const message = 'Check these URLs: https://x.com and https://twitter.com and x.com';
       console.log('Test message:', message);
-      
-      const result = await processXLinks(
-        message,
-        mockLogger
-      );
-      
+
+      const result = await processXLinks(message, mockLogger);
+
       console.log('Test result:', JSON.stringify(result, null, 2));
       console.log('Original links:', result.originalLinks);
       console.log('Transformed links:', result.transformedLinks);
-      
+
       // Verify we found the X links
       expect(result.hasXLinks).toBe(true);
-      
+
       // Verify that the original links were detected
       expect(result.originalLinks.length).toBeGreaterThan(0);
-      
+
       // We should have only one unique transformed URL after deduplication
       expect(result.transformedLinks).toHaveLength(1);
       expect(result.transformedLinks).toContain('https://xcancel.com');
@@ -149,30 +176,30 @@ describe('X/Twitter Transformer Module', () => {
         'https://xcancel.com',
         'https://xcancel.com/profile',
         'https://xcancel.com',
-        'https://xcancel.com/profile'
+        'https://xcancel.com/profile',
       ];
-      
+
       const deduplicated = deduplicateUrls(urls);
-      
+
       expect(deduplicated).toHaveLength(2);
       expect(deduplicated).toContain('https://xcancel.com');
       expect(deduplicated).toContain('https://xcancel.com/profile');
     });
-    
+
     test('should handle empty arrays', () => {
       const deduplicated = deduplicateUrls([]);
       expect(deduplicated).toHaveLength(0);
     });
-    
+
     test('should return the same array if no duplicates', () => {
       const urls = [
         'https://xcancel.com',
         'https://xcancel.com/profile',
-        'https://xcancel.com/status/123'
+        'https://xcancel.com/status/123',
       ];
-      
+
       const deduplicated = deduplicateUrls(urls);
-      
+
       expect(deduplicated).toHaveLength(3);
       expect(deduplicated).toContain('https://xcancel.com');
       expect(deduplicated).toContain('https://xcancel.com/profile');
@@ -181,51 +208,47 @@ describe('X/Twitter Transformer Module', () => {
   });
 
   describe('Regex testing', () => {
-    test('regex should match x.com and twitter.com URLs', () => {
-      // This is the regex pattern from the module
-      const X_TWITTER_URL_REGEX = /(?:https?:\/\/)?(?:www\.)?\b(twitter\.com|x\.com)\b(?:\/[^\s]*)?/gi;
-      
+    test('regex should match x.com, twitter.com, fxtwitter.com, and ios.horse URLs', () => {
       // Simple message with X/Twitter links
-      const message = 'Check these: https://x.com and also https://twitter.com and x.com';
-      
+      const message =
+        'Check these: https://x.com and also https://twitter.com and x.com and ios.horse and fxtwitter.com';
+
       // Use the regex to find matches
-      const matches = [...message.matchAll(new RegExp(X_TWITTER_URL_REGEX))].map(m => m[0]);
-      
+      const matches = [...message.matchAll(new RegExp(X_TWITTER_URL_REGEX))].map((m) => m[0]);
+
       // Verify that we found the three URLs
-      expect(matches).toHaveLength(3);
+      expect(matches).toHaveLength(5);
       expect(matches).toContain('https://x.com');
       expect(matches).toContain('https://twitter.com');
       expect(matches).toContain('x.com');
+      expect(matches).toContain('ios.horse');
+      expect(matches).toContain('fxtwitter.com');
     });
-    
+
     test('should not match domains that contain x.com or twitter.com as substrings', () => {
-      // This is the regex pattern from the module
-      const X_TWITTER_URL_REGEX = /(?:https?:\/\/)?(?:www\.)?\b(twitter\.com|x\.com)\b(?:\/[^\s]*)?/gi;
-      
       // Message with domains that shouldn't match
-      const message = 'Check these: https://netflix.com and also https://phoenix.com and fxtwitter.com and mytwitter.com';
-      
+      const message =
+        'Check these: https://netflix.com and also https://phoenix.com and mytwitter.com';
+
       // Use the regex to find matches
-      const matches = [...message.matchAll(new RegExp(X_TWITTER_URL_REGEX))].map(m => m[0]);
-      
+      const matches = [...message.matchAll(new RegExp(X_TWITTER_URL_REGEX))].map((m) => m[0]);
+
       // Verify that we didn't find any matches
       expect(matches).toHaveLength(0);
     });
-    
+
     test('should match x.com and twitter.com with subdirectories', () => {
-      // This is the regex pattern from the module
-      const X_TWITTER_URL_REGEX = /(?:https?:\/\/)?(?:www\.)?\b(twitter\.com|x\.com)\b(?:\/[^\s]*)?/gi;
-      
       // Message with domains that have subdirectories
-      const message = 'Check these: https://x.com/profile/123 and also https://twitter.com/username/status/456';
-      
+      const message =
+        'Check these: https://x.com/profile/123 and also https://twitter.com/username/status/456';
+
       // Use the regex to find matches
-      const matches = [...message.matchAll(new RegExp(X_TWITTER_URL_REGEX))].map(m => m[0]);
-      
+      const matches = [...message.matchAll(new RegExp(X_TWITTER_URL_REGEX))].map((m) => m[0]);
+
       // Verify that we found the correct matches
       expect(matches).toHaveLength(2);
       expect(matches).toContain('https://x.com/profile/123');
       expect(matches).toContain('https://twitter.com/username/status/456');
     });
   });
-}); 
+});


### PR DESCRIPTION
Adds fxtwitter.com and ios.horse link detection for replying with xcancel.com alternative links.

Removes an unused import of a missing module too so all tests can pass.