### PR TITLE
Remove ios.horse; add vxtwitter

### DIFF
--- a/camille-bot/src/shared/regex/patterns.ts
+++ b/camille-bot/src/shared/regex/patterns.ts
@@ -12,14 +12,14 @@
  * @returns A RegExp that matches the specific bot command
  */
 export function createBotCommandRegex(
-  botId: string | undefined, 
-  command: string, 
+  botId: string | undefined,
+  command: string,
   captureContent = false
 ): RegExp {
-  const pattern = botId 
+  const pattern = botId
     ? `^<@${botId}(?:\\|[^>]+)?>\\s+${command}${captureContent ? '(?:\\s+(.*))?$' : '$'}`
     : `^<@[A-Z0-9]+(?:\\|[^>]+)?>\\s+${command}${captureContent ? '(?:\\s+(.*))?$' : '$'}`;
-  
+
   return new RegExp(pattern, 'i');
 }
 
@@ -42,7 +42,8 @@ export const SLACK_MENTION_REGEX = /<@([A-Z0-9]+)(?:\|[^>]+)?>/g;
  * Matches URLs formatted by Slack as <URL> or <URL|text>
  * This is the preferred pattern for link detection in Slack messages
  */
-export const SLACK_FORMATTED_URL_REGEX = /<((?:https?:\/\/)?(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,63}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*))[^>]*>/gi;
+export const SLACK_FORMATTED_URL_REGEX =
+  /<((?:https?:\/\/)?(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,63}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*))[^>]*>/gi;
 
 /**
  * Comprehensive URL regex pattern
@@ -50,14 +51,16 @@ export const SLACK_FORMATTED_URL_REGEX = /<((?:https?:\/\/)?(?:www\.)?[-a-zA-Z0-
  * Handles various TLDs and subdomains
  * This is the preferred pattern for all URL matching in the codebase
  */
-export const EXTENDED_URL_REGEX = /(?:https?:\/\/)?(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,63}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi;
+export const EXTENDED_URL_REGEX =
+  /(?:https?:\/\/)?(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,63}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi;
 
 /**
  * X/Twitter URL regex pattern
- * Matches URLs from twitter.com or x.com domains
+ * Matches URLs from twitter.com, x.com, fxtwitter.com, and vxtwitter.com domains
  * Uses word boundaries to ensure exact domain matching
  */
-export const X_TWITTER_URL_REGEX = /(?:https?:\/\/)?(?:www\.)?\b(twitter\.com|x\.com|fxtwitter\.com|ios\.horse)\b(?:\/[^\s]*)?/gi;
+export const X_TWITTER_URL_REGEX =
+  /(?:https?:\/\/)?(?:www\.)?\b(twitter\.com|x\.com|fxtwitter\.com|vxtwitter\.com)\b(?:\/[^\s]*)?/gi;
 
 // ============================
 // KARMA PATTERNS
@@ -98,7 +101,7 @@ export function createKarmaQueryRegex(botId: string | undefined): RegExp {
   const pattern = botId
     ? `<@${botId}(?:\\|[^>]+)?>\\s+karma\\s+<@([A-Z0-9]+)(?:\\|[^>]+)?>`
     : `<@[A-Z0-9]+(?:\\|[^>]+)?>\\s+karma\\s+<@([A-Z0-9]+)(?:\\|[^>]+)?>`;
-  
+
   return new RegExp(pattern, 'i');
 }
 
@@ -111,7 +114,7 @@ export function createLeaderboardRegex(botId: string | undefined): RegExp {
   const pattern = botId
     ? `<@${botId}(?:\\|[^>]+)?>\\s+leaderboard`
     : `<@[A-Z0-9]+(?:\\|[^>]+)?>\\s+leaderboard`;
-  
+
   return new RegExp(pattern, 'i');
 }
 

--- a/camille-bot/src/x-transformer/__tests__/x-transformer.test.ts
+++ b/camille-bot/src/x-transformer/__tests__/x-transformer.test.ts
@@ -103,21 +103,21 @@ describe('X/Twitter Transformer Module', () => {
       expect(result.transformedLinks).toContain('https://xcancel.com/profile/user2');
     });
 
-    test('should handle ios.horse links correctly', async () => {
+    test('should handle fxtwitter.com links correctly', async () => {
       const result = await processXLinks(
-        'Check this link: https://ios.horse/profile/mergesort',
+        'Check this link: https://fxtwitter.com/profile/someone_else',
         mockLogger
       );
 
       expect(result.hasXLinks).toBe(true);
       expect(result.originalLinks).toHaveLength(1);
       expect(result.transformedLinks).toHaveLength(1);
-      expect(result.transformedLinks[0]).toBe('https://xcancel.com/profile/mergesort');
+      expect(result.transformedLinks[0]).toBe('https://xcancel.com/profile/someone_else');
     });
 
-    test('should handle fxtwitter.com links correctly', async () => {
+    test('should handle vxtwitter.com links correctly', async () => {
       const result = await processXLinks(
-        'Check this link: https://fxtwitter.com/profile/someone_else',
+        'Check this link: https://vxtwitter.com/profile/someone_else',
         mockLogger
       );
 
@@ -140,7 +140,7 @@ describe('X/Twitter Transformer Module', () => {
 
     test('should ignore bare X/Twitter domains', async () => {
       const result = await processXLinks(
-        'Mentioning x.com, ios.horse, fxtwitter.com, and https://x.com/ should not trigger a reply',
+        'Mentioning x.com, fxtwitter.com, vxtwitter.com, and https://x.com/ should not trigger a reply',
         mockLogger
       );
 
@@ -230,21 +230,21 @@ describe('X/Twitter Transformer Module', () => {
   });
 
   describe('Regex testing', () => {
-    test('regex should match x.com, twitter.com, fxtwitter.com, and ios.horse URLs', () => {
+    test('regex should match x.com, twitter.com, fxtwitter.com, and vxtwitter.com URLs', () => {
       // Simple message with X/Twitter links
       const message =
-        'Check these: https://x.com and also https://twitter.com and x.com and ios.horse and fxtwitter.com';
+        'Check these: https://x.com and also https://twitter.com and x.com and fxtwitter.com and vxtwitter.com';
 
       // Use the regex to find matches
       const matches = [...message.matchAll(new RegExp(X_TWITTER_URL_REGEX))].map((m) => m[0]);
 
-      // Verify that we found the three URLs
+      // Verify that we found the URLs
       expect(matches).toHaveLength(5);
       expect(matches).toContain('https://x.com');
       expect(matches).toContain('https://twitter.com');
       expect(matches).toContain('x.com');
-      expect(matches).toContain('ios.horse');
       expect(matches).toContain('fxtwitter.com');
+      expect(matches).toContain('vxtwitter.com');
     });
 
     test('should not match domains that contain x.com or twitter.com as substrings', () => {


### PR DESCRIPTION
Remove ios.horse from X_TWITTER_URL_REGEX and tests; add vxtwitter support.

Biscuit changed ios.horse to auto-forward to xcancel now, so there's no need to keep the autoresponder going for it. Instead this swaps vxtwitter into the autoresponder list instead.